### PR TITLE
Minor update to the PEP

### DIFF
--- a/peps/pep-0750.rst
+++ b/peps/pep-0750.rst
@@ -203,8 +203,8 @@ As with f-strings, this is an arbitrary string that defines how to present the v
     assert template.args[1].format_spec == ".2f"
 
 Format specifications in f-strings can themselves contain interpolations. This
-is permitted in template strings as well; ``Interpolation.format_spec`` is set
-to the eagerly evaluated result:
+is permitted in template strings as well; ``format_spec`` is set to the eagerly 
+evaluated result:
 
 .. code-block:: python
    

--- a/peps/pep-0750.rst
+++ b/peps/pep-0750.rst
@@ -115,7 +115,7 @@ The ``Template`` Type
 ---------------------
 
 Template strings evaluate to an instance of a new type, ``Template``, found
-in the ``<TBC>`` module:
+in the ``<TBC>`` module (proposed: ``types``):
 
 .. code-block:: python
 
@@ -202,7 +202,16 @@ As with f-strings, this is an arbitrary string that defines how to present the v
     template = t"Value: {value:.2f}"
     assert template.args[1].format_spec == ".2f"
 
-<Example with interpolation inside the format_spec>
+Format specifications in f-strings can themselves contain interpolations. This
+is permitted in template strings as well; ``Interpolation.format_spec`` is set
+to the eagerly evaluated result:
+
+.. code-block:: python
+   
+    value = 42
+    precision = 2
+    template = t"Value: {value:.{precision}f}"
+    assert template.args[1].format_spec == ".2f"
 
 If no format specification is provided, ``format_spec`` defaults to an empty 
 string (``""``). This matches the ``format_spec`` parameter of Python's 
@@ -1024,9 +1033,9 @@ source text:
 
 .. code-block:: python
 
-    spec = ".2f"
     value = 42
-    template = t"{value:{spec}}"
+    precision = 2
+    template = t"Value: {value:.{precision}f}"
     assert template.args[1].format_spec == ".2f"
 
 We do not anticipate that these limitations will be a significant issue in practice.

--- a/peps/pep-0750.rst
+++ b/peps/pep-0750.rst
@@ -115,7 +115,7 @@ The ``Template`` Type
 ---------------------
 
 Template strings evaluate to an instance of a new type, ``Template``, found
-in the ``types`` module:
+in the ``<TBC>`` module:
 
 .. code-block:: python
 
@@ -137,7 +137,7 @@ any interpolations in the literal:
 
 The use of ``@dataclass`` in the definition of ``Template`` above (and 
 ``Interpolation`` below) is meant to be suggestive; the exact implementation 
-in ``cpython`` may differ, but developers can expect that ``Template`` instances 
+in CPython may differ, but developers can expect that ``Template`` instances 
 can be constructed and utilized in the same way as a typical dataclass.
 
 See `Interleaving of Template.args`_ below for more information on how the 
@@ -154,7 +154,7 @@ Like ``Template``, it is a new concrete type found in the ``types`` module:
 
     @dataclass(frozen=True)
     class Interpolation:
-        value: Any
+        value: object
         expr: str
         conv: Literal["a", "r", "s"] | None = None
         format_spec: str = ""
@@ -201,6 +201,8 @@ As with f-strings, this is an arbitrary string that defines how to present the v
     value = 42.0
     template = t"Value: {value:.2f}"
     assert template.args[1].format_spec == ".2f"
+
+<Example with interpolation inside the format_spec>
 
 If no format specification is provided, ``format_spec`` defaults to an empty 
 string (``""``). This matches the ``format_spec`` parameter of Python's 
@@ -273,8 +275,8 @@ a ``SyntaxError``:
 Support for the Debug Specifier
 -------------------------------
 
-The debug specifier, ``=``, is supported in template strings but behaves 
-slightly differently than in f-strings. The specifier
+The debug specifier, ``=``, is supported in template strings and behaves similarly
+to how it behaves in f-strings. The specifier
 was introduced in `gh-80998 <https://github.com/python/cpython/issues/80998>`_
 outside of any PEP. The distinction in behavior is due to technical limitations
 of the implementation.


### PR DESCRIPTION
I did a first pass and I have some comments (I still need to do another two three passes for a full-on review):
- I'm not sure about the `types` module. It seems that it mostly provides types that are the result of calling `type` on some objects. It would be the first exported symbol that does not with the suffix `Type` AFAIU.
- We should add to the specification of the `format_spec` that in case there's interpolations, they're eagerly evaluated.
- I'm not sure about the comment that the debug `=` symbol behaves differently to f-strings. F-strings actually behave the exact same way. If someone `ast.parse`s an f-string, they'll get an AST tree very similar to our `Template.args`.